### PR TITLE
Added SymbolClass Tag exporter and replacer

### DIFF
--- a/build_rabcdasm.d
+++ b/build_rabcdasm.d
@@ -103,7 +103,7 @@ int main()
 		if (haveLZMA)
 			flags ~= " " ~ LZMA_FLAGS;
 
-		foreach (program; ["rabcasm", "rabcdasm", "abcexport", "abcreplace", "swfbinexport", "swfbinreplace", "swfdecompress", "swf7zcompress"])
+		foreach (program; ["rabcasm", "rabcdasm", "abcexport", "abcreplace", "swfbinexport", "swfbinreplace", "swfdecompress", "swf7zcompress", "scexport", "screplace"])
 			compile(program);
 
 		if (haveLZMA)

--- a/scexport.d
+++ b/scexport.d
@@ -1,0 +1,48 @@
+/*
+ *  Copyright 2010, 2011 Vladimir Panteleev <vladimir@thecybershadow.net>
+ *  This file is part of RABCDAsm.
+ *
+ *  RABCDAsm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  RABCDAsm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with RABCDAsm.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+module abcexport;
+
+import std.file;
+import std.path;
+import std.conv;
+import std.stdio;
+import swffile;
+
+void main(string[] args)
+{
+	if (args.length == 1)
+		throw new Exception("No file specified");
+	foreach (arg; args[1..$])
+		try
+		{
+			scope swf = SWFFile.read(cast(ubyte[])read(arg));
+			foreach (ref tag; swf.tags)
+				if (tag.type == TagType.SymbolClass)
+				{
+					ubyte[] abc;
+					abc = tag.data;
+					std.file.write(stripExtension(arg) ~ ".sc", abc);
+					break;
+				}
+			if (count == 0)
+				throw new Exception("No SymbolClass tags found");
+		}
+		catch (Exception e)
+			writefln("Error while processing %s: %s", arg, e);
+}

--- a/screplace.d
+++ b/screplace.d
@@ -1,0 +1,41 @@
+/*
+ *  Copyright 2010, 2011, 2012 Vladimir Panteleev <vladimir@thecybershadow.net>
+ *  This file is part of RABCDAsm.
+ *
+ *  RABCDAsm is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  RABCDAsm is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with RABCDAsm.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+module abcreplace;
+
+import std.file;
+import std.conv;
+import swffile;
+
+void main(string[] args)
+{
+	if (args.length != 3)
+		throw new Exception("Bad arguments. Usage: screplace file.swf SymbolClass.sc");
+	auto swf = SWFFile.read(cast(ubyte[])read(args[1]));
+	uint count;
+	foreach (ref tag; swf.tags)
+		if (tag.type == TagType.SymbolClass)
+		{
+			auto sc = cast(ubyte[])read(args[2]);
+			tag.data = sc;
+			tag.length = cast(uint)tag.data.length;
+			write(args[1], swf.write());
+			return;
+		}
+	throw new Exception("SymbolClass tag not found in file");
+}


### PR DESCRIPTION
It is useful to have ability to export and replace SymbolClass tag if we wish to use RABCDasm for (de)obfuscation purposes.

Maybe it looks not so nice when we have so much exporters and replacers, and it could be nicer to create one universal exported\replacer, and use then for any tags like:
export swffile.swf DoABC
export swffile.swf DefineBinaryData
etc

But at this moment I'm not sure about this and did separate SymbolClass exported\replacer to add more flexibility and ability to rename any packages and classes.

Could be nice to create SymbolClass parser to make readable text file as output and to convert this file after any changes back to the binary format, but my D skills are not so good, I do this myself in my C# RABCDOb (Robust ABC (De)Obfuscator) project prototype ;)
