### PR TITLE
Get RABCDAsm compiling with latest dlang

### DIFF
--- a/disassembler.d
+++ b/disassembler.d
@@ -89,6 +89,9 @@ final class StringBuilder
 		buf[pos++] = c;
 	}
 
+	void opOpAssign(string op : "~", V)(V s) {
+		put(s);
+	}
 	alias put opCatAssign;
 
 	void write(T)(T v)

--- a/zlibx.d
+++ b/zlibx.d
@@ -25,7 +25,7 @@ ubyte[] exactUncompress(ubyte[] srcbuf, size_t destlen)
 	err = etc.c.zlib.inflateInit2(&zs, 15);
 	if (err)
 	{
-		delete destbuf;
+		destbuf.destroy();
 		throw new ZlibException(err);
 	}
 
@@ -35,7 +35,7 @@ ubyte[] exactUncompress(ubyte[] srcbuf, size_t destlen)
 		if (err != Z_OK && err != Z_STREAM_END)
 		{
 		Lerr:
-			delete destbuf;
+			destbuf.destroy();
 			etc.c.zlib.inflateEnd(&zs);
 			throw new ZlibException(err);
 		}

--- a/zlibx.d
+++ b/zlibx.d
@@ -2,6 +2,7 @@
 
 module zlibx;
 
+import core.memory;
 import std.string : format;
 import std.zlib, etc.c.zlib, std.conv;
 static import etc.c.zlib;
@@ -25,7 +26,7 @@ ubyte[] exactUncompress(ubyte[] srcbuf, size_t destlen)
 	err = etc.c.zlib.inflateInit2(&zs, 15);
 	if (err)
 	{
-		destbuf.destroy();
+		GC.free(destbuf.ptr);
 		throw new ZlibException(err);
 	}
 
@@ -35,7 +36,7 @@ ubyte[] exactUncompress(ubyte[] srcbuf, size_t destlen)
 		if (err != Z_OK && err != Z_STREAM_END)
 		{
 		Lerr:
-			destbuf.destroy();
+			GC.free(destbuf.ptr);
 			etc.c.zlib.inflateEnd(&zs);
 			throw new ZlibException(err);
 		}


### PR DESCRIPTION
Both `opCatAssign` and `destroy` produce deprecation errors
as of the latest dlang (dmd 2.100.0). This commit changes them
both to use the suggested replacements, making RABCDAsm compile
with the latest dlang.