### PR TITLE
disassembler: don't force precision for dumpDouble

### DIFF
--- a/disassembler.d
+++ b/disassembler.d
@@ -1144,7 +1144,7 @@ final class Disassembler
 		else
 		{
 			StaticBuf!(char, 64) buf;
-			formattedWrite(&buf, "%.18g", v);
+			formattedWrite(&buf, "%g", v);
 			char[] s = buf.data();
 
 			static double forceDouble(double d) { static double n; n = d; return n; }


### PR DESCRIPTION
Forcing precision would cause the parsing MAX_DOUBLE to fail which would result in the `.asasm` output being blank, disabling the forced precision allows it to continue without any regressions as far as I can tell.